### PR TITLE
Add preference to use dynamic colors

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -7,6 +7,11 @@
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/2016-09_Zapp.app.androidTest.iml" filepath="$PROJECT_DIR$/.idea/modules/app/2016-09_Zapp.app.androidTest.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/2016-09_Zapp.app.main.iml" filepath="$PROJECT_DIR$/.idea/modules/app/2016-09_Zapp.app.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/2016-09_Zapp.app.unitTest.iml" filepath="$PROJECT_DIR$/.idea/modules/app/2016-09_Zapp.app.unitTest.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/zapp.iml" filepath="$PROJECT_DIR$/.idea/modules/zapp.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/zapp.app.iml" filepath="$PROJECT_DIR$/.idea/modules/app/zapp.app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/zapp.app.androidTest.iml" filepath="$PROJECT_DIR$/.idea/modules/app/zapp.app.androidTest.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/zapp.app.main.iml" filepath="$PROJECT_DIR$/.idea/modules/app/zapp.app.main.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/zapp.app.unitTest.iml" filepath="$PROJECT_DIR$/.idea/modules/app/zapp.app.unitTest.iml" />
     </modules>
   </component>
 </project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -7,11 +7,6 @@
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/2016-09_Zapp.app.androidTest.iml" filepath="$PROJECT_DIR$/.idea/modules/app/2016-09_Zapp.app.androidTest.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/2016-09_Zapp.app.main.iml" filepath="$PROJECT_DIR$/.idea/modules/app/2016-09_Zapp.app.main.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/2016-09_Zapp.app.unitTest.iml" filepath="$PROJECT_DIR$/.idea/modules/app/2016-09_Zapp.app.unitTest.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/zapp.iml" filepath="$PROJECT_DIR$/.idea/modules/zapp.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/zapp.app.iml" filepath="$PROJECT_DIR$/.idea/modules/app/zapp.app.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/zapp.app.androidTest.iml" filepath="$PROJECT_DIR$/.idea/modules/app/zapp.app.androidTest.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/zapp.app.main.iml" filepath="$PROJECT_DIR$/.idea/modules/app/zapp.app.main.iml" />
-      <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/zapp.app.unitTest.iml" filepath="$PROJECT_DIR$/.idea/modules/app/zapp.app.unitTest.iml" />
     </modules>
   </component>
 </project>

--- a/app/src/main/java/de/christinecoenen/code/zapp/app/ZappApplicationBase.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/app/ZappApplicationBase.kt
@@ -3,6 +3,7 @@ package de.christinecoenen.code.zapp.app
 import android.app.Application
 import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate
+import com.google.android.material.color.DynamicColors
 import de.christinecoenen.code.zapp.R
 import de.christinecoenen.code.zapp.app.settings.repository.SettingsRepository
 import de.christinecoenen.code.zapp.repositories.ChannelRepository
@@ -55,6 +56,11 @@ abstract class ZappApplicationBase : Application() {
 
 		val settingsRepository = SettingsRepository(this)
 		AppCompatDelegate.setDefaultNightMode(settingsRepository.uiMode)
+
+		// apply dynamic colors to all activities if enabled by user
+		if (settingsRepository.dynamicColors && DynamicColors.isDynamicColorAvailable()) {
+			DynamicColors.applyToActivitiesIfAvailable(this)
+		}
 	}
 
 	override fun attachBaseContext(base: Context?) {

--- a/app/src/main/java/de/christinecoenen/code/zapp/app/settings/repository/SettingsRepository.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/app/settings/repository/SettingsRepository.kt
@@ -40,6 +40,9 @@ class SettingsRepository(context: Context) {
 	val downloadToSdCard: Boolean
 		get() = preferences.getBoolean(context.getString(R.string.pref_key_download_to_sd_card), true)
 
+	val dynamicColors: Boolean
+		get() = preferences.getBoolean(context.getString(R.string.pref_key_dynamic_colors), true)
+
 	val uiMode: Int
 		get() {
 			val uiMode = preferences.getString(context.getString(R.string.pref_key_ui_mode), null)

--- a/app/src/main/java/de/christinecoenen/code/zapp/app/settings/ui/SettingsFragment.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/app/settings/ui/SettingsFragment.kt
@@ -8,6 +8,9 @@ import androidx.navigation.fragment.findNavController
 import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
+import androidx.preference.SwitchPreferenceCompat
+import com.google.android.material.color.DynamicColors
+import com.google.android.material.snackbar.Snackbar
 import de.christinecoenen.code.zapp.R
 import de.christinecoenen.code.zapp.app.settings.helper.ShortcutPreference
 import de.christinecoenen.code.zapp.app.settings.repository.SettingsRepository
@@ -18,6 +21,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
 	companion object {
 
 		private const val PREF_SHORTCUTS = "pref_shortcuts"
+		private const val PREF_DYNAMIC_COLORS = "dynamic_colors"
 		private const val PREF_UI_MODE = "pref_ui_mode"
 		private const val PREF_LANGUAGE = "pref_key_language"
 		private const val PREF_CHANNEL_SELECTION = "pref_key_channel_selection"
@@ -26,6 +30,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
 
 	private lateinit var settingsRepository: SettingsRepository
 	private lateinit var shortcutPreference: ShortcutPreference
+	private lateinit var dynamicColorsPreference: SwitchPreferenceCompat
 	private lateinit var uiModePreference: ListPreference
 	private lateinit var languagePreference: ListPreference
 	private lateinit var channelSelectionPreference: Preference
@@ -54,6 +59,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
 		addPreferencesFromResource(R.xml.preferences)
 
 		shortcutPreference = preferenceScreen.findPreference(PREF_SHORTCUTS)!!
+		dynamicColorsPreference = preferenceScreen.findPreference(PREF_DYNAMIC_COLORS)!!
 		uiModePreference = preferenceScreen.findPreference(PREF_UI_MODE)!!
 		languagePreference = preferenceScreen.findPreference(PREF_LANGUAGE)!!
 		channelSelectionPreference = preferenceScreen.findPreference(PREF_CHANNEL_SELECTION)!!
@@ -62,6 +68,15 @@ class SettingsFragment : PreferenceFragmentCompat() {
 		languagePreference.value = LanguageHelper.getCurrentLanguageTag()
 		languagePreference.entries = languages.values.toTypedArray()
 		languagePreference.entryValues = languages.keys.toTypedArray()
+
+		// only show the preference for dynamic colors when available (Android 12 and up)
+		dynamicColorsPreference.isVisible = DynamicColors.isDynamicColorAvailable()
+		dynamicColorsPreference.setOnPreferenceChangeListener { _, _ ->
+			view?.let {
+				Snackbar.make(it, R.string.requires_restart, Snackbar.LENGTH_SHORT).show()
+			}
+			true
+		}
 
 		channelSelectionPreference.setOnPreferenceClickListener {
 			val direction =

--- a/app/src/main/java/de/christinecoenen/code/zapp/app/settings/ui/SettingsFragment.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/app/settings/ui/SettingsFragment.kt
@@ -69,7 +69,7 @@ class SettingsFragment : PreferenceFragmentCompat() {
 		languagePreference.entries = languages.values.toTypedArray()
 		languagePreference.entryValues = languages.keys.toTypedArray()
 
-		// only show the preference for dynamic colors when available (Android 12 and up)
+		// only show the preference for dynamic colors when available (Android 12 and up)<
 		dynamicColorsPreference.isVisible = DynamicColors.isDynamicColorAvailable()
 		dynamicColorsPreference.setOnPreferenceChangeListener { _, _ ->
 			view?.let {

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -73,6 +73,8 @@
 
 	<string name="error_prefixed_message">Error: %s</string>
 
+	<!-- warning -->
+	<string name="requires_restart">Please restart the app in order for the changes to come into effect.</string>
 
 	<!-- menus & buttons -->
 	<string name="action_play">Play</string>
@@ -144,6 +146,9 @@
 
 	<string name="pref_download_to_sd_card_title">Download to sd card</string>
 	<string name="pref_download_to_sd_card_summary">Video files will be saved to sd card if present.</string>
+
+	<string name="pref_dynamic_colors">Dynamic colors</string>
+	<string name="pref_dynamic_colors_summary">Choose accent colors based on the wallpaper.</string>
 
 	<!-- notifications -->
 	<string name="notification_channel_name_background_playback">Background player</string>

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
+	<string name="pref_key_dynamic_colors">dynamic_colors</string>
 	<string name="pref_key_ui_mode">pref_ui_mode</string>
 	<string name="pref_key_language">pref_key_language</string>
 	<string name="pref_key_detail_landscape">pref_detail_landscape</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -73,6 +73,8 @@
 
 	<string name="error_prefixed_message">Fehler: %s</string>
 
+	<!-- warning -->
+	<string name="requires_restart">Neustart benötigt um die Änderungen anzuwenden.</string>
 
 	<!-- menus & buttons -->
 	<string name="action_play">Play</string>
@@ -144,6 +146,9 @@
 
 	<string name="pref_download_to_sd_card_title">Downloads auf SD-Karte</string>
 	<string name="pref_download_to_sd_card_summary">Wenn verfügbar, werden Video-Dateien auf die SD-Karte gespeichert.</string>
+
+	<string name="pref_dynamic_colors">Dynamische Farben</string>
+	<string name="pref_dynamic_colors_summary">Wähle Akzentfarben basierend auf dem Geräte-Hintergrund.</string>
 
 	<!-- notifications -->
 	<string name="notification_channel_name_background_playback">Hintergrund-Videoplayer</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -6,6 +6,12 @@
 		android:icon="@drawable/ic_outline_palette_24"
 		android:title="Aussehen">
 
+		<SwitchPreferenceCompat
+			android:defaultValue="true"
+			android:title="@string/pref_dynamic_colors"
+			android:summary="@string/pref_dynamic_colors_summary"
+			android:key="@string/pref_key_dynamic_colors"/>
+
 		<ListPreference
 			android:defaultValue="default"
 			android:entries="@array/pref_ui_mode_names"


### PR DESCRIPTION
Hey,
as the app recently got migrated to MD3 (which is awesome :) ), I thought it'd be a nice addition to allow users to use [Dynamic Colors](https://m3.material.io/styles/color/dynamic-color/overview) instead of the default red/pink accent colors. Changing the preference requires an app restart as dynamic colors need to get initialized before `super#onCreate()` of the activities is getting called.
If there are any suggestions for improvements, I'm open for it.
Cheers