### PR TITLE
proof of concept: support for subscribing to search queries

### DIFF
--- a/app/schemas/de.christinecoenen.code.zapp.persistence.Database/5.json
+++ b/app/schemas/de.christinecoenen.code.zapp.persistence.Database/5.json
@@ -1,0 +1,246 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "f1c3bab7699a6783b71aa0a4c5edaa60",
+    "entities": [
+      {
+        "tableName": "PersistedMediathekShow",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `createdAt` INTEGER NOT NULL, `showUpdatedAt` INTEGER, `downloadId` INTEGER NOT NULL, `downloadedAt` INTEGER, `downloadedVideoPath` TEXT, `downloadStatus` INTEGER NOT NULL, `downloadProgress` INTEGER NOT NULL, `bookmarked` INTEGER NOT NULL, `bookmarkedAt` INTEGER, `lastPlayedBackAt` INTEGER, `playbackPosition` INTEGER NOT NULL, `videoDuration` INTEGER NOT NULL, `apiId` TEXT NOT NULL, `topic` TEXT NOT NULL, `title` TEXT NOT NULL, `description` TEXT, `channel` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `size` INTEGER NOT NULL, `duration` TEXT, `filmlisteTimestamp` INTEGER NOT NULL, `websiteUrl` TEXT, `subtitleUrl` TEXT, `videoUrl` TEXT NOT NULL, `videoUrlLow` TEXT, `videoUrlHd` TEXT)",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "showUpdatedAt",
+            "columnName": "showUpdatedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadId",
+            "columnName": "downloadId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadedAt",
+            "columnName": "downloadedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadedVideoPath",
+            "columnName": "downloadedVideoPath",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "downloadStatus",
+            "columnName": "downloadStatus",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "downloadProgress",
+            "columnName": "downloadProgress",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBookmarked",
+            "columnName": "bookmarked",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkedAt",
+            "columnName": "bookmarkedAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "lastPlayedBackAt",
+            "columnName": "lastPlayedBackAt",
+            "affinity": "INTEGER",
+            "notNull": false
+          },
+          {
+            "fieldPath": "playbackPosition",
+            "columnName": "playbackPosition",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "videoDuration",
+            "columnName": "videoDuration",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediathekShow.apiId",
+            "columnName": "apiId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediathekShow.topic",
+            "columnName": "topic",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediathekShow.title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediathekShow.description",
+            "columnName": "description",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediathekShow.channel",
+            "columnName": "channel",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediathekShow.timestamp",
+            "columnName": "timestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediathekShow.size",
+            "columnName": "size",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediathekShow.duration",
+            "columnName": "duration",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediathekShow.filmlisteTimestamp",
+            "columnName": "filmlisteTimestamp",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediathekShow.websiteUrl",
+            "columnName": "websiteUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediathekShow.subtitleUrl",
+            "columnName": "subtitleUrl",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediathekShow.videoUrl",
+            "columnName": "videoUrl",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "mediathekShow.videoUrlLow",
+            "columnName": "videoUrlLow",
+            "affinity": "TEXT",
+            "notNull": false
+          },
+          {
+            "fieldPath": "mediathekShow.videoUrlHd",
+            "columnName": "videoUrlHd",
+            "affinity": "TEXT",
+            "notNull": false
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_PersistedMediathekShow_apiId",
+            "unique": true,
+            "columnNames": [
+              "apiId"
+            ],
+            "orders": [],
+            "createSql": "CREATE UNIQUE INDEX IF NOT EXISTS `index_PersistedMediathekShow_apiId` ON `${TABLE_NAME}` (`apiId`)"
+          }
+        ],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "SearchQuery",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`query` TEXT NOT NULL, `date` INTEGER NOT NULL, PRIMARY KEY(`query`))",
+        "fields": [
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "query"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      },
+      {
+        "tableName": "QuerySubscription",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`query` TEXT NOT NULL, PRIMARY KEY(`query`))",
+        "fields": [
+          {
+            "fieldPath": "query",
+            "columnName": "query",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "query"
+          ]
+        },
+        "indices": [],
+        "foreignKeys": []
+      }
+    ],
+    "views": [],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'f1c3bab7699a6783b71aa0a4c5edaa60')"
+    ]
+  }
+}

--- a/app/src/main/java/de/christinecoenen/code/zapp/app/KoinModules.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/app/KoinModules.kt
@@ -27,6 +27,7 @@ import de.christinecoenen.code.zapp.models.channels.json.JsonChannelList
 import de.christinecoenen.code.zapp.persistence.Database
 import de.christinecoenen.code.zapp.repositories.ChannelRepository
 import de.christinecoenen.code.zapp.repositories.MediathekRepository
+import de.christinecoenen.code.zapp.repositories.QuerySubscriptionRepository
 import de.christinecoenen.code.zapp.repositories.SearchRepository
 import de.christinecoenen.code.zapp.utils.api.UserAgentInterceptor
 import io.noties.markwon.Markwon
@@ -57,6 +58,7 @@ class KoinModules {
 			single { Database.getInstance(androidContext()) }
 			single { MediathekRepository(get()) }
 			single { SearchRepository(get()) }
+			single { QuerySubscriptionRepository(get()) }
 			single { PersistedPlaybackPositionRepository(get()) } bind IPlaybackPositionRepository::class
 			single {
 				WorkManagerDownloadController(
@@ -87,10 +89,10 @@ class KoinModules {
 			viewModel { ContinueWatchingViewModel(get()) }
 			viewModel { DownloadsViewModel(get()) }
 			viewModel { ProgramInfoViewModel(androidApplication(), get()) }
-			viewModel { parameters -> MediathekListFragmentViewModel(get(), parameters.get()) }
+			viewModel { MediathekListFragmentViewModel(get(), get()) }
 			viewModel { MediathekFilterViewModel() }
 			viewModel { ShowMenuHelperViewModel(get(), get()) }
-			viewModel { SearchViewModel(get(), get(), get()) }
+			viewModel { SearchViewModel(get(), get(), get(), get()) }
 		}
 
 	}

--- a/app/src/main/java/de/christinecoenen/code/zapp/app/main/MainActivity.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/app/main/MainActivity.kt
@@ -109,7 +109,7 @@ class MainActivity : AppCompatActivity(), MenuProvider {
 		appBarConfiguration = AppBarConfiguration(
 			setOf(
 				R.id.channelListFragment,
-				R.id.mediathekListFragment,
+				R.id.mediathekListBaseFragment,
 				R.id.personalFragment,
 			),
 			fallbackOnNavigateUpListener = ::onSupportNavigateUp

--- a/app/src/main/java/de/christinecoenen/code/zapp/app/mediathek/api/MediathekPagingSource.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/app/mediathek/api/MediathekPagingSource.kt
@@ -14,7 +14,8 @@ import java.io.IOException
 class MediathekPagingSource(
 	private val mediathekApi: IMediathekApiService,
 	private val query: QueryRequest,
-	private val queryInfoResultPublisher: MutableStateFlow<QueryInfoResult?>
+	private val queryInfoResultPublisher: MutableStateFlow<QueryInfoResult?>,
+	private val emptyIfNoQueries: Boolean = false
 ) : PagingSource<Int, MediathekShow>() {
 
 	override fun getRefreshKey(state: PagingState<Int, MediathekShow>): Int? {
@@ -23,6 +24,9 @@ class MediathekPagingSource(
 	}
 
 	override suspend fun load(params: LoadParams<Int>): LoadResult<Int, MediathekShow> {
+		if (query.isEmpty() && emptyIfNoQueries) {
+			return LoadResult.Page(emptyList(), null, null)
+		}
 
 		queryInfoResultPublisher.emit(null)
 

--- a/app/src/main/java/de/christinecoenen/code/zapp/app/mediathek/api/request/QueryRequest.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/app/mediathek/api/request/QueryRequest.kt
@@ -1,6 +1,5 @@
 package de.christinecoenen.code.zapp.app.mediathek.api.request
 
-import android.text.TextUtils
 import androidx.annotation.Keep
 import com.google.gson.annotations.SerializedName
 import java.io.Serializable
@@ -27,36 +26,40 @@ class QueryRequest : Serializable {
 	private val channels: MutableSet<MediathekChannel> = mutableSetOf()
 
 	@Transient
-	private var queryString: String = ""
+	private var queryStrings: MutableSet<String> = mutableSetOf()
 
 	init {
 		resetQueries()
 	}
 
-	fun setChannels(channels: List<MediathekChannel>): QueryRequest {
+	fun setChannels(channels: List<MediathekChannel>): QueryRequest = apply {
 		this.channels.clear()
 		this.channels.addAll(channels)
 
 		resetQueries()
-
-		return this
 	}
 
-	fun setQueryString(queryString: String): QueryRequest {
-		this.queryString = queryString
+	fun setQueryString(queryString: String): QueryRequest = apply {
+		this.queryStrings.clear()
+		this.queryStrings.add(queryString)
 
 		resetQueries()
+	}
 
-		return this
+	fun setQueryStrings(queryStrings: List<String>): QueryRequest = apply {
+		this.queryStrings.clear()
+		this.queryStrings.addAll(queryStrings)
+
+		resetQueries()
 	}
 
 	private fun resetQueries() {
 		queries.clear()
 
 		// set search query
-		if (!TextUtils.isEmpty(this.queryString)) {
-			queries.add(Query(this.queryString, "title", "topic"))
-		}
+		queries.addAll(queryStrings.filter { it.isNotEmpty() }.map { queryString ->
+			Query(queryString, "title", "topic")
+		})
 
 		// We do not allow an empty channel Filter as the result would always be empty.
 		// Instead we filter for all available channels. This also excludes all channels
@@ -71,6 +74,8 @@ class QueryRequest : Serializable {
 			queries.add(Query(allowedChannel.apiId, "channel"))
 		}
 	}
+
+	fun isEmpty() = queries.isEmpty()
 
 	override fun toString(): String {
 		return "QueryRequest(sortBy='$sortBy', sortOrder='$sortOrder', future=$future, offset=$offset, size=$size, queries=$queries)"

--- a/app/src/main/java/de/christinecoenen/code/zapp/app/mediathek/ui/list/MediathekListBaseFragment.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/app/mediathek/ui/list/MediathekListBaseFragment.kt
@@ -1,0 +1,57 @@
+package de.christinecoenen.code.zapp.app.mediathek.ui.list
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.os.bundleOf
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.adapter.FragmentStateAdapter
+import com.google.android.material.tabs.TabLayoutMediator
+import de.christinecoenen.code.zapp.R
+import de.christinecoenen.code.zapp.databinding.MediathekListBaseFragmentBinding
+
+class MediathekListBaseFragment: Fragment() {
+	private var _binding: MediathekListBaseFragmentBinding? = null
+	private val binding get() = _binding!!
+
+	override fun onCreateView(
+		inflater: LayoutInflater,
+		container: ViewGroup?,
+		savedInstanceState: Bundle?
+	): View {
+		_binding = MediathekListBaseFragmentBinding.inflate(layoutInflater)
+		return binding.root
+	}
+
+	override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+		super.onViewCreated(view, savedInstanceState)
+
+		binding.mediathekPager.adapter = MediathekListAdapter(this)
+		val mediator = TabLayoutMediator(binding.tabLayout, binding.mediathekPager) { tab, position ->
+			tab.text = when (position) {
+				0 -> getString(R.string.fragment_mediathek_recent)
+				1 -> getString(R.string.fragment_mediathek_subscriptions)
+				else -> throw IllegalStateException("Only two tabs implemented.")
+			}
+		}
+		mediator.attach()
+	}
+
+	override fun onDestroyView() {
+		super.onDestroyView()
+		_binding = null
+	}
+}
+
+class MediathekListAdapter(fragment: Fragment): FragmentStateAdapter(fragment) {
+	override fun getItemCount(): Int = 2
+
+	override fun createFragment(position: Int): Fragment {
+		val subscriptionsOnly = position == 1
+
+		return MediathekListFragment().apply {
+			arguments = bundleOf(MediathekListFragment.EXTRA_SUBSCRIPTIONS_ONLY to subscriptionsOnly)
+		}
+	}
+}

--- a/app/src/main/java/de/christinecoenen/code/zapp/app/mediathek/ui/list/MediathekListFragment.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/app/mediathek/ui/list/MediathekListFragment.kt
@@ -26,11 +26,13 @@ import de.christinecoenen.code.zapp.databinding.MediathekListFragmentBinding
 import de.christinecoenen.code.zapp.databinding.ViewNoShowsBinding
 import de.christinecoenen.code.zapp.models.shows.MediathekShow
 import de.christinecoenen.code.zapp.utils.system.LifecycleOwnerHelper.launchOnCreated
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 import java.net.UnknownServiceException
@@ -73,6 +75,12 @@ class MediathekListFragment : Fragment(),
 			viewLifecycleOwner,
 			Lifecycle.State.RESUMED
 		)
+
+		if (requireArguments().getBoolean(EXTRA_SUBSCRIPTIONS_ONLY)) {
+			lifecycleScope.launch(Dispatchers.IO) {
+				viewmodel.subscriptionsOnly.emit(true)
+			}
+		}
 
 		return binding.root
 	}
@@ -147,7 +155,7 @@ class MediathekListFragment : Fragment(),
 	}
 
 	override fun onShowClicked(show: MediathekShow) {
-		val directions = MediathekListFragmentDirections.toMediathekDetailFragment(show)
+		val directions = MediathekListBaseFragmentDirections.toMediathekDetailFragment(show)
 		findNavController().navigate(directions)
 	}
 
@@ -177,5 +185,9 @@ class MediathekListFragment : Fragment(),
 	private fun updateNoShowsMessage(loadState: LoadState) {
 		val isAdapterEmpty = adapter.itemCount == 0 && loadState is LoadState.NotLoading
 		noShowsBinding.group.isVisible = isAdapterEmpty
+	}
+
+	companion object {
+		const val EXTRA_SUBSCRIPTIONS_ONLY = "extra_subscriptions_only"
 	}
 }

--- a/app/src/main/java/de/christinecoenen/code/zapp/app/personal/details/DetailsBaseFragment.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/app/personal/details/DetailsBaseFragment.kt
@@ -10,7 +10,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.recyclerview.widget.RecyclerView
 import de.christinecoenen.code.zapp.app.mediathek.ui.helper.ShowMenuHelper
-import de.christinecoenen.code.zapp.app.mediathek.ui.list.MediathekListFragmentDirections
+import de.christinecoenen.code.zapp.app.mediathek.ui.list.MediathekListBaseFragmentDirections
 import de.christinecoenen.code.zapp.app.mediathek.ui.list.adapter.MediathekShowListItemListener
 import de.christinecoenen.code.zapp.app.mediathek.ui.list.adapter.PagedMediathekShowListAdapter
 import de.christinecoenen.code.zapp.databinding.PersonalDetailsFragmentBinding
@@ -85,7 +85,7 @@ abstract class DetailsBaseFragment : Fragment(), MediathekShowListItemListener {
 
 	override fun onShowClicked(show: MediathekShow) {
 		val directions =
-			MediathekListFragmentDirections.toMediathekDetailFragment(show)
+			MediathekListBaseFragmentDirections.toMediathekDetailFragment(show)
 		findNavController().navigate(directions)
 	}
 

--- a/app/src/main/java/de/christinecoenen/code/zapp/app/search/results/SearchResultsFragment.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/app/search/results/SearchResultsFragment.kt
@@ -133,6 +133,19 @@ class SearchResultsFragment : Fragment(), MediathekShowListItemListener {
 				mediathekResultLoadStatusAdapter.setIsLoading()
 			}
 		}
+
+		binding.subscribeQueryButton.setOnClickListener {
+			viewModel.toggleSubscription()
+		}
+
+		viewLifecycleOwner.launchOnResumed {
+			viewModel.isSubscribed.collectLatest { isSubscribed ->
+				binding.subscribeQueryButton.setText(
+					if (isSubscribed) R.string.fragment_mediathek_unsubscribe
+					else R.string.fragment_mediathek_subscribe
+				)
+			}
+		}
 	}
 
 	override fun onDestroyView() {

--- a/app/src/main/java/de/christinecoenen/code/zapp/app/settings/repository/SettingsRepository.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/app/settings/repository/SettingsRepository.kt
@@ -72,7 +72,7 @@ class SettingsRepository(context: Context) {
 
 	val startFragment: Int
 		get() = when (preferences.getString(context.getString(R.string.pref_key_start_tab), "live")) {
-			"mediathek" -> R.id.mediathekListFragment
+			"mediathek" -> R.id.mediathekListBaseFragment
 			"personal" -> R.id.personalFragment
 			else -> R.id.channelListFragment
 		}

--- a/app/src/main/java/de/christinecoenen/code/zapp/models/search/QuerySubscription.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/models/search/QuerySubscription.kt
@@ -1,0 +1,9 @@
+package de.christinecoenen.code.zapp.models.search
+
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+
+@Entity
+data class QuerySubscription(
+	@PrimaryKey val query: String
+)

--- a/app/src/main/java/de/christinecoenen/code/zapp/persistence/Database.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/persistence/Database.kt
@@ -8,14 +8,16 @@ import androidx.room.RoomDatabase
 import androidx.room.TypeConverters
 import androidx.room.migration.Migration
 import androidx.sqlite.db.SupportSQLiteDatabase
+import de.christinecoenen.code.zapp.models.search.QuerySubscription
 import de.christinecoenen.code.zapp.models.search.SearchQuery
 import de.christinecoenen.code.zapp.models.shows.PersistedMediathekShow
 
 @Database(
-	entities = [PersistedMediathekShow::class, SearchQuery::class],
-	version = 4,
+	entities = [PersistedMediathekShow::class, SearchQuery::class, QuerySubscription::class],
+	version = 5,
 	autoMigrations = [
 		AutoMigration(from = 3, to = 4),
+		AutoMigration(from = 4, to = 5)
 	],
 	exportSchema = true
 )
@@ -81,4 +83,5 @@ abstract class Database : RoomDatabase() {
 
 	abstract fun searchDao(): SearchDao
 
+	abstract fun subscriptionDao(): QuerySubscriptionDao
 }

--- a/app/src/main/java/de/christinecoenen/code/zapp/persistence/QuerySubscriptionDao.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/persistence/QuerySubscriptionDao.kt
@@ -1,0 +1,25 @@
+package de.christinecoenen.code.zapp.persistence
+
+import androidx.room.Dao
+import androidx.room.Insert
+import androidx.room.OnConflictStrategy
+import androidx.room.Query
+import de.christinecoenen.code.zapp.models.search.QuerySubscription
+
+@Dao
+interface QuerySubscriptionDao {
+	@Query("SELECT * FROM QuerySubscription")
+	fun getAll(): List<QuerySubscription>
+
+	@Insert(onConflict = OnConflictStrategy.REPLACE)
+	fun insert(querySubscription: QuerySubscription)
+
+	@Query("DELETE FROM QuerySubscription WHERE `query` = :query")
+	fun delete(query: String)
+
+	@Query("DELETE FROM QuerySubscription")
+	fun deleteAll()
+
+	@Query("SELECT EXISTS(SELECT * FROM QuerySubscription WHERE `query` = :query)")
+	suspend fun exists(query: String): Boolean
+}

--- a/app/src/main/java/de/christinecoenen/code/zapp/repositories/QuerySubscriptionRepository.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/repositories/QuerySubscriptionRepository.kt
@@ -1,0 +1,42 @@
+package de.christinecoenen.code.zapp.repositories
+
+import de.christinecoenen.code.zapp.models.search.QuerySubscription
+import de.christinecoenen.code.zapp.persistence.Database
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class QuerySubscriptionRepository(private val database: Database) {
+	suspend fun listSubscriptions() = withContext(Dispatchers.IO) {
+		database
+			.subscriptionDao()
+			.getAll()
+	}
+
+	suspend fun saveSubscription(query: String) = withContext(Dispatchers.IO) {
+		if (query.isBlank()) {
+			return@withContext
+		}
+
+		database
+			.subscriptionDao()
+			.insert(QuerySubscription(query.trim()))
+	}
+
+	suspend fun isSubscribed(query: String) = withContext(Dispatchers.IO) {
+		database
+			.subscriptionDao()
+			.exists(query)
+	}
+
+	suspend fun deleteSubscription(query: String) = withContext(Dispatchers.IO) {
+		database
+			.subscriptionDao()
+			.delete(query)
+	}
+
+	suspend fun deleteAllSubscriptions() = withContext(Dispatchers.IO) {
+		database
+			.subscriptionDao()
+			.deleteAll()
+	}
+}

--- a/app/src/main/java/de/christinecoenen/code/zapp/tv/main/MainFragment.kt
+++ b/app/src/main/java/de/christinecoenen/code/zapp/tv/main/MainFragment.kt
@@ -29,7 +29,7 @@ class MainFragment : Fragment() {
 		binding.tabs.setupWithViewPager(binding.viewpager)
 
 		val selectedTabIndex = when (settingsRepository.startFragment) {
-			R.id.mediathekListFragment -> 1
+			R.id.mediathekListBaseFragment -> 1
 			else -> 0
 		}
 		val selectedTab = binding.tabs.getTabAt(selectedTabIndex)

--- a/app/src/main/res/layout/mediathek_list_base_fragment.xml
+++ b/app/src/main/res/layout/mediathek_list_base_fragment.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	xmlns:app="http://schemas.android.com/apk/res-auto"
+	xmlns:tools="http://schemas.android.com/tools"
+	android:layout_width="match_parent"
+	android:layout_height="match_parent"
+	android:orientation="vertical"
+	tools:context="app.mediathek.ui.list.MediathekListBaseFragment">
+
+	<com.google.android.material.tabs.TabLayout
+		android:id="@+id/tab_layout"
+		android:layout_width="wrap_content"
+		android:background="@android:color/transparent"
+		android:layout_height="wrap_content"
+		app:tabMode="scrollable" />
+
+	<androidx.viewpager2.widget.ViewPager2
+		android:id="@+id/mediathek_pager"
+		android:layout_width="match_parent"
+		android:layout_height="match_parent" />
+
+</LinearLayout>

--- a/app/src/main/res/layout/search_results_fragment.xml
+++ b/app/src/main/res/layout/search_results_fragment.xml
@@ -6,6 +6,14 @@
 	android:layout_height="match_parent"
 	tools:context=".app.search.SearchFragment">
 
+	<com.google.android.material.button.MaterialButton
+		android:id="@+id/subscribe_query_button"
+		android:layout_width="wrap_content"
+		android:layout_height="wrap_content"
+		android:text="@string/fragment_mediathek_subscribe"
+		app:layout_constraintStart_toStartOf="parent"
+		app:layout_constraintTop_toTopOf="parent" />
+
 	<androidx.recyclerview.widget.RecyclerView
 		android:id="@+id/chips"
 		android:layout_width="match_parent"
@@ -14,7 +22,7 @@
 		android:paddingHorizontal="12dp"
 		app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
 		app:layout_constraintBottom_toTopOf="@id/results"
-		app:layout_constraintTop_toTopOf="parent"
+		app:layout_constraintTop_toBottomOf="@id/subscribe_query_button"
 		tools:listitem="@layout/view_mediathek_filter_chip" />
 
 	<androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/menu/activity_main_bottom_nav.xml
+++ b/app/src/main/res/menu/activity_main_bottom_nav.xml
@@ -7,7 +7,7 @@
 		android:title="@string/activity_main_tab_live" />
 
 	<item
-		android:id="@+id/mediathekListFragment"
+		android:id="@+id/mediathekListBaseFragment"
 		android:icon="@drawable/ic_outline_video_library_24"
 		android:title="@string/activity_main_tab_mediathek" />
 

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -33,10 +33,10 @@
 			app:argType="boolean" />
 	</fragment>
 	<fragment
-		android:id="@+id/mediathekListFragment"
-		android:name="de.christinecoenen.code.zapp.app.mediathek.ui.list.MediathekListFragment"
+		android:id="@+id/mediathekListBaseFragment"
+		android:name="de.christinecoenen.code.zapp.app.mediathek.ui.list.MediathekListBaseFragment"
 		android:label="@string/app_name"
-		tools:layout="@layout/mediathek_list_fragment">
+		tools:layout="@layout/mediathek_list_base_fragment">
 		<argument
 			android:name="show_bottom_navigation"
 			android:defaultValue="true"

--- a/app/src/main/res/values-en/strings.xml
+++ b/app/src/main/res/values-en/strings.xml
@@ -43,6 +43,10 @@
 	<string name="fragment_mediathek_confirm_delete_dialog_title">Delete file?</string>
 	<string name="fragment_mediathek_confirm_delete_dialog_text">The video file will be deleted and can be downloaded again.</string>
 	<string name="fragment_mediathek_query_info">%1$s search results from %2$s</string>
+	<string name="fragment_mediathek_subscriptions">Subscriptions</string>
+	<string name="fragment_mediathek_recent">Recent</string>
+	<string name="fragment_mediathek_subscribe">Subscribe</string>
+	<string name="fragment_mediathek_unsubscribe">Unsubscribe</string>
 
 	<!-- personal -->
 	<string name="fragment_personal_no_results_downloads">no downloads found</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -43,6 +43,10 @@
 	<string name="fragment_mediathek_confirm_delete_dialog_title">Datei wirklich löschen?</string>
 	<string name="fragment_mediathek_confirm_delete_dialog_text">Die Video-Datei wird gelöscht und kann später nochmals herunter geladen werden.</string>
 	<string name="fragment_mediathek_query_info">%1$s Suchergebnisse vom %2$s</string>
+	<string name="fragment_mediathek_subscriptions">Abonnements</string>
+	<string name="fragment_mediathek_recent">Neueste</string>
+	<string name="fragment_mediathek_subscribe">Abonnieren</string>
+	<string name="fragment_mediathek_unsubscribe">Deabonnieren</string>
 
 	<!-- personal -->
 	<string name="fragment_personal_no_results_downloads">keine Downloads gefunden</string>


### PR DESCRIPTION
- So ein Feature fände ich persönlich sehr cool um neue Folgen von bestimmten Serien / TV-Sendungen nicht zu verpassen

Beschreibung:
1. Diese PR fügt einen "Abonnements"-Tab in der Mediathek hinzu
2. Diese Abonnements sind Such-Queries
3. Neue Such-Queries können hinzugefügt werden, indem man nach etwas sucht und dann den "Abonnieren"-Button drückt

Es fehlt:
- Übersicht über die "abonnierten" Such-Queries, wo man diese auch wieder löschen kann
- Richtige Einbindung des "Abonnieren" / "Deabonnieren" - Buttons in die UI. Der Plan war, diesen Knopf in das Options Menu zu packen, aber ich habe nicht so ganz rausgefunden warum das Menü in dem Suchergebnis-Fragment unsichtbar ist

Bevor ich weiter daran arbeite, wünsche ich mir erstmal Feedback, ob das in die richtige Richtung geht :)

addresses #348